### PR TITLE
remove colons from headers

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -42,12 +42,12 @@
                         <div id="quorum"></div>
                     </div>
                     <div id="action_picker">
-                        <h6>Channels:</h6>
+                        <h6>Channels</h6>
                         <ul id="chanpicker">
                         </ul>
                     </div>
                     <div id="userlist_wrapper">
-                        <h6>Currently online (<span id="counter">?</span>):</h6>
+                        <h6>Currently online (<span id="counter">?</span>)</h6>
                         <ul id="userlist">
                         </ul>
                     </div>


### PR DESCRIPTION
Colons are clutter.

https://www.k-state.edu/webservices/cms/best-practices/heading-ending-colon.html