### PR TITLE
simplify user list CSS

### DIFF
--- a/htdocs/css/mm.css
+++ b/htdocs/css/mm.css
@@ -298,15 +298,9 @@ footer {
 
 
 #userlist_wrapper {
-    display: inline-block;
-    width: calc(100% - 12px);
-    border-radius: 6px;
     height: calc(100% - 200px);
     padding: 4px;
-    vertical-align: top;
-    position: relative;
     margin: 4px;
-    overflow-y: auto;
 }
 
 h6 {


### PR DESCRIPTION
Many of these styles seem superfluous, so just remove them.

Specifically, the `width` style makes the list just a bit wider than the leftnav, so a scrollbar gets introduced. Removing any messing with the width eliminates the scrollbar.