### PR TITLE
Allow to send message that look like announcements

### DIFF
--- a/htdocs/js/mm.js
+++ b/htdocs/js/mm.js
@@ -661,8 +661,10 @@ async function check_send(el, force=false) {
         const message = el.value;
         // Block people trying to announce themselves...
         if (message.match(/^\s*[-a-z0-9]+\s+\|\s+\S*/)) {
-            alert("It looks like you are trying to announce yourself. This is NOT needed. Your attendance has been recorded. If you are acting as a proxy for others, please click the Proxies button.")
-            return
+            let ok = confirm("It looks like you are trying to announce yourself. This is NOT needed. Your attendance has been recorded; please click \"Cancel\". If you are acting as a proxy for others, please click the Proxies button.\nIf you are NOT announcing yourself, click \"Ok\" to send your message.");
+            if (!ok) {
+                return
+            }
         }
         // Commands?
         let action_m = message.match(/^\/([a-z]+)\s+(\S+)$/);


### PR DESCRIPTION
A regex is used to stop announcements. However, that regex may also block possibly legit messages.

IMHO it is better to make it possible to send any message to the meeting, in order to ensure 100% freedom of speech.

An example of blocked message is:
`ls | more`
that is uncommon for an ASF meeting... but maybe not so uncommon in general for the type of audience?

This patch is changing the dialog into an Ok/Cancel dialog, where selecting "Ok" sends the message and "Cancel" blocks it.
``Fancier'' alternatives are possible, for example showing a yes/no choice, but I am not able to implement them.

As an alternative to this, the dialog may remain a "blocker" but it could suggest a way of editing the message in order to circumvent the regex, like adding a word at the beginning.